### PR TITLE
Add SpamdexingSites feed

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -197,6 +197,11 @@ aggregate:
     source: https://raw.githubusercontent.com/YeSilin/uBlacklist/master/list.txt
     dest: src/aggregations/extra-content-farms/yesil.txt
     type: ublacklist
+  - name: SpamdexingSites
+    homepage: https://github.com/elliotwutingfeng/SpamdexingSites
+    source: https://raw.githubusercontent.com/elliotwutingfeng/SpamdexingSites/main/blocklist_UBL.txt
+    dest: src/aggregations/extra-content-farms/spamdexingsites.txt
+    type: ublacklist
 
 build:
   - source:


### PR DESCRIPTION
I am the maintainer of the SpamdexingSites feed. It targets content farms and is regularly updated.